### PR TITLE
Fix panic due to nil map assignment in trackSplitOffset

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	repo       = "taradaidv/goscout"
-	ver        = "v0.3.1"
+	ver        = "v0.3.2"
 	configFile = ".goscout.json"
 )
 
@@ -42,6 +42,10 @@ func (ui *UI) SetHosts() {
 }
 
 func SetupWindow(fyneWindow fyne.Window, cfg *Config) {
+	if cfg.SplitOffsets == nil {
+		cfg.SplitOffsets = make(map[string]float64)
+	}
+
 	ui := &UI{
 		fyneWindow:       fyneWindow,
 		fyneSelect:       widget.NewSelect(nil, nil),
@@ -54,7 +58,7 @@ func SetupWindow(fyneWindow fyne.Window, cfg *Config) {
 		logsLabel:        widget.NewMultiLineEntry(),
 		connectionTab:    &container.TabItem{},
 		bottomConnection: &fyne.Container{},
-		webdavActive:     false, // Initialize the field
+		webdavActive:     false,
 	}
 
 	defer ui.fyneWindow.Close()


### PR DESCRIPTION
This fix addresses a panic caused by attempting to assign a value to a nil map in the trackSplitOffset function. The issue was resolved by initializing the SplitOffsets map in the Config struct during the setup of the UI. This ensures that the map is not nil before any assignments are made, preventing the panic and ensuring stable execution.